### PR TITLE
feat: adds encryption possibility to private keys

### DIFF
--- a/packages/commons/tools/kms/index.ts
+++ b/packages/commons/tools/kms/index.ts
@@ -1,0 +1,2 @@
+import kms from './kms';
+export default kms;

--- a/packages/commons/tools/kms/kms.ts
+++ b/packages/commons/tools/kms/kms.ts
@@ -1,0 +1,91 @@
+import 'dotenv/config';
+import _ from 'lodash';
+import { KMS } from 'aws-sdk';
+import { ClientConfiguration } from 'aws-sdk/clients/kms';
+const deasync = require('deasync');
+
+const DEFAULT_CLIENT_CONFIGURATION: ClientConfiguration = {
+  apiVersion: '2014-11-01',
+  region: 'us-east-1',
+};
+
+const kms = new KMS(DEFAULT_CLIENT_CONFIGURATION);
+
+const encrypt = async (stringToEncrypt: string): Promise<string> => {
+  const data = await kms
+    .encrypt({
+      KeyId: process.env.KMS_KEY_ID as string,
+      Plaintext: Buffer.from(stringToEncrypt),
+    })
+    .promise();
+  return data.CiphertextBlob!.toString('base64');
+};
+
+const encryptSeveral = async (plainStrings: string[]): Promise<string[]> => {
+  return await Promise.all(_.map(plainStrings, (plainString) => encrypt(plainString)));
+};
+
+const decryptSync = (encryptedString: string): string => {
+  // encryptedString is a plain PrivateKey (default privateKey)
+  if (encryptedString === '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff') return encryptedString;
+
+  let decryptedInfo: KMS.DecryptResponse | unknown = undefined;
+  let kill: boolean = false;
+
+  kms.decrypt(
+    {
+      CiphertextBlob: Buffer.from(encryptedString, 'base64'),
+    },
+    (error, data) => {
+      if (error) {
+        console.log('MKS:decryptSync error:');
+        console.log(error);
+        kill = true;
+      } else {
+        decryptedInfo = data;
+      }
+    }
+  );
+
+  while (decryptedInfo === undefined && !kill) {
+    require('deasync').sleep(25);
+  }
+  if (!decryptedInfo) return encryptedString;
+  return (decryptedInfo as KMS.DecryptResponse).Plaintext!.toString();
+};
+
+const decrypt = async (encryptedString: string): Promise<string> => {
+  const decryptedInfo = await kms
+    .decrypt({
+      CiphertextBlob: Buffer.from(encryptedString, 'base64'),
+    })
+    .promise();
+  return decryptedInfo.Plaintext!.toString();
+};
+
+const decryptSeveral = async (encryptedStrings: string[]): Promise<string[]> => {
+  return await Promise.all(_.map(encryptedStrings, (encryptedString) => decrypt(encryptedString)));
+};
+
+const decryptSeveralSync = (encryptedStrings: string[]): string[] => {
+  return encryptedStrings.map((encryptedString) => decryptSync(encryptedString));
+};
+
+const getDecryptedPrivateKey = async (): Promise<string> => {
+  return await decrypt(process.env.ENCRYPTED_PRIVATE_KEY as string);
+};
+
+const getDecryptedPrivateKeySync = (): string => {
+  return decryptSync(process.env.ENCRYPTED_PRIVATE_KEY as string);
+};
+
+export default {
+  getDecryptedPrivateKey,
+  encrypt,
+  encryptSeveral,
+  decrypt,
+  decryptSeveral,
+  decryptSync,
+  decryptSeveralSync,
+  getDecryptedPrivateKeySync,
+};

--- a/packages/commons/tools/kms/script.ts
+++ b/packages/commons/tools/kms/script.ts
@@ -1,0 +1,69 @@
+import inquirer from 'inquirer';
+import kms from './kms';
+
+const main = async () => {
+  return new Promise((resolve, reject) => {
+    inquirer
+      .prompt([
+        {
+          message: 'Select action to perform',
+          type: 'list',
+          name: 'action',
+          choices: ['encrypt', 'decrypt'],
+        },
+      ])
+      .then(async (answ: any) => {
+        if (answ.action === 'encrypt') {
+          await encrypt();
+        } else {
+          await decrypt();
+        }
+      })
+      .catch(reject);
+  });
+};
+
+const encrypt = async (): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    inquirer
+      .prompt([
+        {
+          message: 'Enter text to encrypt',
+          type: 'password',
+          name: 'toEncrypt',
+        },
+      ])
+      .then(async (answ: any) => {
+        const encryptedString = await kms.encrypt(answ.toEncrypt);
+        console.log('Encrypted string:', encryptedString);
+        resolve();
+      })
+      .catch(reject);
+  });
+};
+
+const decrypt = async (): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    inquirer
+      .prompt([
+        {
+          message: 'Enter text to decrypt',
+          type: 'password',
+          name: 'toDecrypt',
+        },
+      ])
+      .then(async (answ: any) => {
+        const decryptedString = await kms.decrypt(answ.toDecrypt);
+        console.log('Decrypted string:', decryptedString);
+        resolve();
+      })
+      .catch(reject);
+  });
+};
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/contract-utils/.env.example
+++ b/packages/contract-utils/.env.example
@@ -1,27 +1,18 @@
 # Encrypted credentials
+ENCRYPTED_CREDENTIALS=
 KMS_KEY_ID=
-ENCRYPTED_PRIVATE_KEY=
 
-# HTTPs providers
-MAINNET_HTTPS_URL=
-ROPSTEN_HTTPS_URL=
-GOERLI_HTTPS_URL=
-LOCAL_MAINNET_HTTPS_URL=https://127.0.0.1:8545
+# network specific node uri: `"ETH_NODE_URI_" + networkName.toUpperCase()`
+ETH_NODE_URI_MAINNET=https://eth-mainnet.alchemyapi.io/v2/<apiKey>
 
-# WS providers
-MAINNET_WS_URL=
-RINKEBY_WS_URL=
+# network specific mnemonic: `MNEMONIC_${networkName.toUpperCase()}`
+MNEMONIC_MAINNET=<mnemonic for mainnet>
 
 # Account's private keys
-MAINNET_PRIVATE_KEY=
-ROPSTEN_PRIVATE_KEY=
-KOVAN_PRIVATE_KEY=
-GOERLI_PRIVATE_KEY=
-ROPSTEN_2_PRIVATE_KEY=
-KOVAN_2_PRIVATE_KEY=
-GOERLI_2_PRIVATE_KEY=
-FLASHBOTS_PRIVATE_KEY=
-LOCAL_MAINNET_PRIVATE_KEY=0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+MAINNET_1_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ROPSTEN_1_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+POLYGON_1_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+LOCALHOST_1_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 # Mocha (10 minutes)
 MOCHA_TIMEOUT=600000
@@ -32,8 +23,3 @@ COINMARKETCAP_DEFAULT_CURRENCY=USD
 
 # Etherscan (optional, only for verifying smart contracts)
 ETHERSCAN_API_KEY=
-
-# Tenderly
-TENDERLY_PROJECT=
-TENDERLY_USERNAME=
-TENDERLY_ACCESS_TOKEN=

--- a/packages/stealth-txs/.env.example
+++ b/packages/stealth-txs/.env.example
@@ -1,27 +1,26 @@
 # Encrypted credentials
+ENCRYPTED_CREDENTIALS=
 KMS_KEY_ID=
-ENCRYPTED_PRIVATE_KEY=
 
 # HTTPs providers
-MAINNET_HTTPS_URL=
-ROPSTEN_HTTPS_URL=
-GOERLI_HTTPS_URL=
-LOCAL_MAINNET_HTTPS_URL=https://127.0.0.1:8545
+# network specific node uri: `"ETH_NODE_URI_" + networkName.toUpperCase()`
+ETH_NODE_URI_MAINNET=https://eth-mainnet.alchemyapi.io/v2/<apiKey>
 
 # WSs providers
 MAINNET_WS_URL=
 RINKEBY_WS_URL=
 
+# network specific mnemonic: `MNEMONIC_${networkName.toUpperCase()}`
+MNEMONIC_MAINNET=<mnemonic for mainnet>
+
 # Account's private keys
-MAINNET_PRIVATE_KEY=
-ROPSTEN_PRIVATE_KEY=
-KOVAN_PRIVATE_KEY=
-GOERLI_PRIVATE_KEY=
+MAINNET_1_PRIVATE_KEY=
+ROPSTEN_1_PRIVATE_KEY=
+KOVAN_1_PRIVATE_KEY=
+GOERLI_1_PRIVATE_KEY=
 ROPSTEN_2_PRIVATE_KEY=
 KOVAN_2_PRIVATE_KEY=
 GOERLI_2_PRIVATE_KEY=
-FLASHBOTS_PRIVATE_KEY=
-LOCAL_MAINNET_PRIVATE_KEY=0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 # Mocha (10 minutes)
 MOCHA_TIMEOUT=600000
@@ -32,8 +31,3 @@ COINMARKETCAP_DEFAULT_CURRENCY=USD
 
 # Etherscan (optional, only for verifying smart contracts)
 ETHERSCAN_API_KEY=
-
-# Tenderly
-TENDERLY_PROJECT=
-TENDERLY_USERNAME=
-TENDERLY_ACCESS_TOKEN=

--- a/packages/stealth-txs/hardhat.config.ts
+++ b/packages/stealth-txs/hardhat.config.ts
@@ -1,6 +1,7 @@
 import hardhatConfig from '../commons/hardhat.config';
 
 const config = hardhatConfig({
+  networks: ['mainnet'],
   solidity: {
     compilers: [
       {

--- a/packages/strategies-keep3r/.env.example
+++ b/packages/strategies-keep3r/.env.example
@@ -1,23 +1,19 @@
 # network specific node uri: `"ETH_NODE_URI_" + networkName.toUpperCase()`
 ETH_NODE_URI_MAINNET=https://eth-mainnet.alchemyapi.io/v2/<apiKey>
-# generic node uri (if no specific found):
-ETH_NODE_URI=https://eth-{{networkName}}.infura.io/v3/<apiKey>
 
 # network specific mnemonic: `MNEMONIC_${networkName.toUpperCase()}`
 MNEMONIC_MAINNET=<mnemonic for mainnet>
-# generic mnemonic (if no specific found):
-MNEMONIC=<mnemonic>
 
 # Account's private keys
-MAINNET_PRIVATE_KEY=
-FTM_PRIVATE_KEY=
-POLYGON_PRIVATE_KEY=
-ROPSTEN_PRIVATE_KEY=
-FLASHBOTS_PRIVATE_KEY=
+MAINNET_1_PRIVATE_KEY=
+FTM_1_PRIVATE_KEY=
+POLYGON_1_PRIVATE_KEY=
+ROPSTEN_1_PRIVATE_KEY=
+FLASHBOTS_1_PRIVATE_KEY=
 
 # Encrypted credentials
+ENCRYPTED_CREDENTIALS=
 KMS_KEY_ID=
-ENCRYPTED_PRIVATE_KEY=
 
 # Mocha (10 minutes)
 MOCHA_TIMEOUT=600000

--- a/packages/strategies-keep3r/hardhat.config.ts
+++ b/packages/strategies-keep3r/hardhat.config.ts
@@ -1,6 +1,7 @@
 import hardhatConfig from '../commons/hardhat.config';
 
 const config = hardhatConfig({
+  networks: ['mainnet'],
   solidity: {
     compilers: [
       {

--- a/packages/yswaps/.env.example
+++ b/packages/yswaps/.env.example
@@ -1,20 +1,22 @@
 # Encrypted credentials
+ENCRYPTED_CREDENTIALS=
 KMS_KEY_ID=
-ENCRYPTED_PRIVATE_KEY=
 
-# HTTPs providers
-MAINNET_HTTPS_URL=
-ROPSTEN_HTTPS_URL=
-LOCAL_MAINNET_HTTPS_URL=https://127.0.0.1:8545
+# network specific node uri: `"ETH_NODE_URI_" + networkName.toUpperCase()`
+ETH_NODE_URI_MAINNET=https://eth-mainnet.alchemyapi.io/v2/<apiKey>
+
+# network specific mnemonic: `MNEMONIC_${networkName.toUpperCase()}`
+MNEMONIC_MAINNET=<mnemonic for mainnet>
 
 # Account's private keys
-MAINNET_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ROPSTEN_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-POLYGON_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-LOCAL_MAINNET_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+MAINNET_1_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ROPSTEN_1_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+POLYGON_1_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+FANTOM_1_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+LOCALHOST_1_PRIVATE_KEY=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
-# Mocha
-MOCHA_TIMEOUT=600000 # 10 minutes
+# Mocha (10 minutes)
+MOCHA_TIMEOUT=600000
 
 # Coinmarketcap (optional, only for gas reporting)
 COINMARKETCAP_API_KEY=

--- a/packages/yswaps/hardhat.config.ts
+++ b/packages/yswaps/hardhat.config.ts
@@ -1,6 +1,7 @@
 import hardhatConfig from '../commons/hardhat.config';
 
 const config = hardhatConfig({
+  networks: ['mainnet', 'ropsten', 'polygon', 'fantom'],
   namedAccounts: {
     deployer: 0, // yMECH Alejo
     governor: {

--- a/packages/yswaps/test/integration/fork-block-numbers.ts
+++ b/packages/yswaps/test/integration/fork-block-numbers.ts
@@ -1,5 +1,5 @@
 export default {
-  'mainnet-swappers': 13533134,
+  'mainnet-swappers': 13533135,
   'fantom-swappers': 16548550,
   'polygon-swappers': 17080654,
 };


### PR DESCRIPTION
There might be some need of adding new `networks` if I am losing any on a project, but it should be a 1 sec fix. Overall I think this arch. makes more sense. 
- Will only include defined networks per project
- No need of defining all env variables if there is a network you are not using
- Programattically search for more than 1 private key on environment
- Allow to chose between private keys inclusion or mnemonic
- Everything is pretty easy to change

Sad:
- No tests, but not a big deal honestly. We will end up testing our tooling some day. 