### PR TITLE
refactor: remove swapped event from swapper

### DIFF
--- a/packages/yswaps/contracts/swappers/async/AsyncSwapper.sol
+++ b/packages/yswaps/contracts/swappers/async/AsyncSwapper.sol
@@ -4,10 +4,6 @@ pragma solidity >=0.8.4 <0.9.0;
 import '../Swapper.sol';
 
 interface IAsyncSwapper is ISwapper {
-  event Swapped(address _receiver, address _tokenIn, address _tokenOut, uint256 _amountIn, uint256 _minAmountOut, bytes _data);
-
-  event SwappedMultiple(bytes _data);
-
   function swap(
     address _receiver,
     address _tokenIn,
@@ -54,6 +50,5 @@ abstract contract AsyncSwapper is IAsyncSwapper, Swapper {
   ) external virtual override onlyTradeFactory {
     _assertPreSwap(_receiver, _tokenIn, _tokenOut, _amountIn, _minAmountOut);
     _executeSwap(_receiver, _tokenIn, _tokenOut, _amountIn, _data);
-    emit Swapped(_receiver, _tokenIn, _tokenOut, _amountIn, _minAmountOut, _data);
   }
 }

--- a/packages/yswaps/contracts/swappers/async/MultiCallOptimizedSwapper.sol
+++ b/packages/yswaps/contracts/swappers/async/MultiCallOptimizedSwapper.sol
@@ -50,8 +50,6 @@ contract MultiCallOptimizedSwapper is IMultiCallOptimizedSwapper, MultipleAsyncS
     }
 
     if (!_success) revert MultiCallRevert();
-
-    emit Swapped(_receiver, _tokenIn, _tokenOut, _amountIn, _minAmountOut, _data);
   }
 
   function swapMultiple(bytes calldata _data) external override onlyTradeFactory {
@@ -72,8 +70,6 @@ contract MultiCallOptimizedSwapper is IMultiCallOptimizedSwapper, MultipleAsyncS
     }
 
     if (!_success) revert MultiCallRevert();
-
-    emit SwappedMultiple(_data);
   }
 
   // TODO: SHOULD BE USED

--- a/packages/yswaps/contracts/swappers/sync/SyncSwapper.sol
+++ b/packages/yswaps/contracts/swappers/sync/SyncSwapper.sol
@@ -4,8 +4,6 @@ pragma solidity >=0.8.4 <0.9.0;
 import '../Swapper.sol';
 
 interface ISyncSwapper is ISwapper {
-  event Swapped(address _receiver, address _tokenIn, address _tokenOut, uint256 _amountIn, uint256 _maxSlippage, bytes _data);
-
   // solhint-disable-next-line func-name-mixedcase
   function SLIPPAGE_PRECISION() external view returns (uint256);
 
@@ -59,6 +57,5 @@ abstract contract SyncSwapper is ISyncSwapper, Swapper {
   ) external virtual override onlyTradeFactory {
     _assertPreSwap(_receiver, _tokenIn, _tokenOut, _amountIn, _maxSlippage);
     _executeSwap(_receiver, _tokenIn, _tokenOut, _amountIn, _maxSlippage, _data);
-    emit Swapped(_receiver, _tokenIn, _tokenOut, _amountIn, _maxSlippage, _data);
   }
 }


### PR DESCRIPTION
I'm taking the decision to NOT emit de `data` since its going to be really expensive, and if we want to get this stuff, we can do it via thegraph call handlers.