### PR TITLE
feat: add a way for automated tokemak claims

### DIFF
--- a/packages/strategies-keep3r/contracts/interfaces/jobs/v2/ICalldataV2Keep3rJob.sol
+++ b/packages/strategies-keep3r/contracts/interfaces/jobs/v2/ICalldataV2Keep3rJob.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.8;
+
+import './IV2Keep3rJob.sol';
+
+interface ICalldataV2Keep3rJob is IKeep3rJob {
+
+  // Actions by Keeper
+  event Worked(address _strategy, bytes _callData, address _keeper, uint256 _credits);
+
+  // Actions forced by governor
+  event ForceWorked(address _strategy, bytes _callData);
+
+  function updateAllowedSelector(address _strategy, bytes4 _allowedSelector) external;
+
+  function workable(address _strategy, bytes calldata _callData) external view returns (bool);
+
+  // Keeper actions
+  function work(address _strategy, bytes calldata _callData) external returns (uint256 _credits);
+
+  // Mechanics keeper bypass
+  function forceWork(address _strategy, bytes calldata _callData) external;
+
+}

--- a/packages/strategies-keep3r/contracts/interfaces/jobs/v2/IV2Keeper.sol
+++ b/packages/strategies-keep3r/contracts/interfaces/jobs/v2/IV2Keeper.sol
@@ -19,4 +19,6 @@ interface IV2Keeper {
   function tend(address _strategy) external;
 
   function harvest(address _strategy) external;
+
+  function execute(address _strategy, bytes calldata _callData) external returns (bool success, bytes memory result);
 }

--- a/packages/strategies-keep3r/contracts/jobs/v2/CalldataV2Keep3rJob.sol
+++ b/packages/strategies-keep3r/contracts/jobs/v2/CalldataV2Keep3rJob.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import './V2Keep3rPublicJob.sol';
+
+import '../../interfaces/jobs/v2/ICalldataV2Keep3rJob.sol';
+
+/* A Keep3r job that requires function calldata from the Keep3r */
+contract CalldataV2Keep3rJob is V2Keep3rPublicJob, ICalldataV2Keep3rJob {
+
+  // Get the allowed function selector of a strategy - can't allow the keep3r to call any function they want
+  mapping(address => bytes4) public allowedSelector;
+
+  constructor(
+    address _mechanicsRegistry,
+    address _yOracle,
+    address _keep3r,
+    address _bond,
+    uint256 _minBond,
+    uint256 _earned,
+    uint256 _age,
+    bool _onlyEOA,
+    address _v2Keeper,
+    uint256 _workCooldown
+  )
+    V2Keep3rPublicJob(_mechanicsRegistry, _yOracle, _keep3r, _bond, _minBond, _earned, _age, _onlyEOA, _v2Keeper, _workCooldown)
+  // solhint-disable-next-line no-empty-blocks
+  {
+
+  }
+
+  function updateAllowedSelector(address _strategy, bytes4 _allowedSelector) external override onlyGovernorOrMechanic {
+    _updateAllowedSelector(_strategy, _allowedSelector);
+  }
+
+  function _updateAllowedSelector(address _strategy, bytes4 _allowedSelector) internal {
+    allowedSelector[_strategy] = _allowedSelector;
+  }
+
+  function _workInternal(address _strategy, bytes memory _callData) internal returns (uint256 _credits) {
+    uint256 _initialGas = gasleft();
+    require(_workable(_strategy), 'CalldataV2Keep3rJob::work:not-workable');
+
+    _work(_strategy, _callData);
+
+    _credits = _calculateCredits(_initialGas);
+
+    emit Worked(_strategy, _callData, msg.sender, _credits);
+  }
+
+  function workable(address _strategy, bytes calldata _callData) external view override returns (bool) {
+    return _workable(_strategy, _callData);
+  }
+
+  function _workable(address _strategy, bytes memory _callData) internal view returns (bool) {
+    if (!super._workable(_strategy)) return false;
+
+    bytes4 _selector;
+    assembly {
+      _selector := _callData
+    }
+    
+    return _selector == allowedSelector[_strategy];
+  }
+
+  function _work(address _strategy, bytes memory _callData) internal {
+    lastWorkAt[_strategy] = block.timestamp;
+    IV2Keeper(v2Keeper).execute(_strategy, _callData);
+  }
+
+  // Keep3r actions
+  function work(address _strategy, bytes calldata _callData) external override notPaused onlyKeeper(msg.sender) returns (uint256 _credits) {
+    _credits = _workInternal(_strategy, _callData);
+    _paysKeeperAmount(msg.sender, _credits);
+  }
+
+  function work(address _strategy) external override returns (uint256 _credits) {}
+
+  function workable(address _strategy) external view override returns (bool) {
+    return false;
+  }
+
+  // Mechanics keeper bypass
+  function forceWork(address _strategy, bytes calldata _callData) external override onlyGovernorOrMechanic {
+    _forceWork(_strategy, _callData);
+  }
+
+  function _forceWork(address _strategy, bytes memory _callData) internal {
+    _work(_strategy, _callData);
+    emit ForceWorked(_strategy, _callData);
+  }
+
+}

--- a/packages/strategies-keep3r/contracts/jobs/v2/V2Keeper.sol
+++ b/packages/strategies-keep3r/contracts/jobs/v2/V2Keeper.sol
@@ -54,6 +54,10 @@ contract V2Keeper is MachineryReady, IV2Keeper {
     IBaseStrategy(_strategy).harvest();
   }
 
+  function execute(address _strategy, bytes calldata _callData) external override onlyValidJob returns (bool _success, bytes memory _result) {
+    (_success, _result) = _strategy.call(_callData);
+  }
+
   modifier onlyValidJob() {
     require(_validJobs.contains(msg.sender), 'V2Keeper::onlyValidJob:msg-sender-not-valid-job');
     _;


### PR DESCRIPTION
## Description

For our tokemak strats, we need to call a special function to claim TOKE ([this one](https://github.com/charlesndalton/tokemak-eth-strat/blob/c42eda89e9c661de45ac70ac2db89e25b942a6e6/contracts/Strategy.sol#L257)). Ideally, we'd automate this, which isn't possible through the existing keep3r jobs. This is one idea on how to allow for this.

Essentially, we'd have a new type of job called a CalldataV2Keep3rJob where Yearn would be able to specify an approved function selector for a strategy. A keep3r would call *function work(address _strategy, bytes calldata _callData)*, passing in the required calldata. In our case, the approved function selector would be the bytes4 equivalent of claimRewards, and keep3rs would be able to call claimRewards by passing in this information. 

Since there is additional information required by the keep3r, we'd also need to add some docs on how they can get this calldata.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Text update
- [ ] Other

## Change details

Detail the changes that occur if necessary.

## Resources

Any screenshots, links or relevant resources to explain better the changes.
